### PR TITLE
fix(if): do not warn for >10 files

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ module.exports = function (condition, child, branch) {
         throw new Error('gulp-if: child action is required');
     }
 
+    child.setMaxListeners(0);
+    
     var process = function(file) {
 
         if (!branch) {

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,26 @@ describe('gulp-if', function() {
 		});
 
 	});
+  
+  // http://nodejs.org/api/events.html#events_emitter_setmaxlisteners_n
+	it('should not warn for >10 listeners', function() {
+		var child = through(function() {});
+		var s = gulpif(true, child);
+
+		function write(n) {
+			s.write({
+				path: 'path/'+n,
+				content: new Buffer(' '+n)
+			});
+		}
+
+		for (var n=0; n<11; n++) {
+			write(n);
+		}
+		//ajoslin: Only way I could find to test this warning
+		//https://github.com/joyent/node/blob/master/test/simple/test-event-emitter-check-listener-leaks.js#L32
+		should.not.exist(child._events.data.warned);
+	});
 
 
 });


### PR DESCRIPTION
gulp-if currently gives a warning if you pass >10 files through, because EventEmitter has a [default maxListeners of 10](http://nodejs.org/api/events.html#events_emitter_setmaxlisteners_n).

We can set this to unlimited by doing `setMaxListeners(0)`.

We could also refactor it so there is only one child listener, but it would be slightly more complicated.
