### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
To make the code-style of 4-wide tabs be enforced.  So I don't have to constantly manually do it.

Most editors support editorconfig.
