### PR TITLE
fix(if): do not add child listener if match fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,10 @@ module.exports = function (condition, child, branch) {
 
     var process = function(file) {
 
-        if (!branch) {
-            child.once('data', this.emit.bind(this, 'data'));
-        }
-
         if (match(file, condition)) {
+            if (!branch) {
+                child.once('data', this.emit.bind(this, 'data'));
+            }
             child.write(file);
             return;
         }

--- a/test/index.js
+++ b/test/index.js
@@ -66,6 +66,20 @@ describe('gulp-if', function() {
 			done();
 		});
 
+		it('should not listen for child events if test does not match', function() {
+			var called = 0;
+			var child = through();
+			child.once = function() { called++; };
+			var s = gulpif(/pass/, child);
+
+			s.write({ path: 'pass', content: new Buffer('test') });
+			called.should.equal(1);
+			s.write({ path: 'fail', content: new Buffer('test') });
+			called.should.equal(1);
+			s.write({ path: 'pass', content: new Buffer('test') });
+			called.should.equal(2);
+		});
+
 	});
 
 


### PR DESCRIPTION
I was doing this (simplified):

``` js
gulp.src('src/**/*.js', 'template/**/*.html')
  .pipe(gulpif(/html$/, html2js())
  .pipe(concat('script.js')
  .pipe(gulp.dest('dist'))
```

And I noticed I was getting duplicates in script.js. I finally figured out it was because whenever the html2js() stream emitted a `data` event, all of the non-html files would be listening for that event too and re-emit themselves as new data.

This fixes that.  Only files that pass the match will listen to the child stream's data event.
