### PR TITLE
Deleting test files and images from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "engines": {
     "node": ">= 0.10.0"
   },
+  "files": [
+    "index.js"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
Excludes unnecessary files from redist package. The average user does not need tests and promotional images in the package. They need developers.

About [README.md and LICENSE](https://docs.npmjs.com/files/package.json#files):
> Certain files are always included, regardless of settings:
>   * package.json
>   * README (and its variants)
>   * CHANGELOG (and its variants)
>   * LICENSE / LICENCE