### PR TITLE
Support for lazy evaluation (Fixes #75)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function lazyTransform (lazyFn) {
 }
 
 function lazify (lazyFn) {
-	return ( !lazyFn || lazyFn._transform ) ? lazyFn : lazyTransform (lazyFn);
+	return ( typeof lazyFn === 'function' && !lazyFn._transform ) ? lazyTransform (lazyFn) : lazyFn;
 }
 
 module.exports = function (condition, trueChild, falseChild, minimatchOptions) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,19 @@ var match = require('gulp-match');
 var ternaryStream = require('ternary-stream');
 var through2 = require('through2');
 
+function lazyTransform (lazyFn) {
+	var fnCached;
+	var transform = function () {
+		var fn = fnCached || lazyFn ();
+		fn._transform.apply ( fn, arguments );
+	};
+	return through2.obj(transform);
+}
+
+function lazify (lazyFn) {
+	return ( !lazyFn || lazyFn._transform ) ? lazyFn : lazyTransform (lazyFn);
+}
+
 module.exports = function (condition, trueChild, falseChild, minimatchOptions) {
 	if (!trueChild) {
 		throw new Error('gulp-if: child action is required');
@@ -12,12 +25,12 @@ module.exports = function (condition, trueChild, falseChild, minimatchOptions) {
 	if (typeof condition === 'boolean') {
 		// no need to evaluate the condition for each file
 		// other benefit is it never loads the other stream
-		return condition ? trueChild : (falseChild || through2.obj());
+		return condition ? lazify(trueChild) : (falseChild ? lazify(falseChild) : through2.obj());
 	}
 
 	function classifier (file) {
 		return !!match(file, condition, minimatchOptions);
 	}
 
-	return ternaryStream(classifier, trueChild, falseChild);
+	return ternaryStream(classifier, lazify(trueChild), lazify(falseChild));
 };

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var through2 = require('through2');
 function lazyTransform (lazyFn) {
 	var fnCached;
 	var transform = function () {
-		var fn = fnCached || lazyFn ();
 		fn._transform.apply ( fn, arguments );
+		var fn = fnCached || ( fnCached = lazyFn () );
 	};
 	return through2.obj(transform);
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var through2 = require('through2');
 function lazyTransform (lazyFn) {
 	var fnCached;
 	var transform = function () {
-		fn._transform.apply ( fn, arguments );
 		var fn = fnCached || ( fnCached = lazyFn () );
+		return fn._transform.apply ( this, arguments );
 	};
 	return through2.obj(transform);
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "gulp-match": "^1.0.3",
+    "is-stream": "^1.1.0",
     "ternary-stream": "^2.0.1",
     "through2": "^2.0.1"
   },


### PR DESCRIPTION
@robrich as I understand it you're willing to add this functionality if the syntax is good, well I don't think it can get better than this.

Eager evaluation:
```javascript
.pipe ( gulp.if ( true, myPlugin () ) )
```

Lazy evaluation:
```javascript
.pipe ( gulp.if ( true, () => myPlugin () ) )
```

The advantage of this is that we don't have to pay the cost of requiring expensive plugins if we don't use them, basically the following becomes possible:

```javascript
.pipe ( gulp.if ( true, () => require ( 'my-plugin' )() ) )
```

What do you think?